### PR TITLE
Don't use ignore-platform-reqs when installing mongo-php-adapter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
 install:
   - travis_retry composer self-update
   # Install a polyfill for Mongo extension on PHP 7
-  - if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then travis_retry composer require "alcaeus/mongo-php-adapter=^1.0.0" --ignore-platform-reqs; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then travis_retry composer config "platform.ext-mongo" "1.6.16" && composer require alcaeus/mongo-php-adapter; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:2} == "5." ]]; then travis_retry composer update; fi
   - composer info -i
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,9 @@ matrix:
 before_install:
   # Disable XDebug speed up test execution.
   - phpenv config-rm xdebug.ini || return 0
-  # Enable Mongo extension on PHP 5
+  # Enable correct MongoDB driver for each PHP version
   - if [[ ${TRAVIS_PHP_VERSION:0:2} == "5." ]]; then echo "extension=mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini || return 0; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then echo "extension=mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini || return 0; fi
   - echo "memory_limit=2G" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini || return 0
 
 install:


### PR DESCRIPTION
Using `ignore-platform-reqs` can cause a bunch of errors down the line (e.g. by installing incompatible package versions not suited for the current PHP version). Thus, `ext-mongodb` is provided via `config.platform`.