### PR TITLE
 Refactor saga handling to work with DomainMessage instead of event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+## v0.5.x
+
+The major change in this version, is that `sagas` are now handled with 
+the `DomainMessage` instead of the `event`. This makes it more consistent with the 
+rest of the broadway framework, where all event listeners are handled with the 
+`DomainMessage`.
+
+
+#### BC breaks
+
+- The `Saga::handle*()` arguments are reordered with `State`, `event`, `DomainMessage`   
+
+#### Other changes
+
+-  `StaticallyConfiguredSagaInterface::configuration` array of callables gets a second argument which holds the `DomainMessage`. This way it is not necessary to put the identifier in each `event` because you can fetch it from the `DomainMessage`
+ 

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,9 +14,9 @@ Sagas in Broadway
 
 In Broadway, a saga is a class that extends `Broadway\Saga\Saga`. It uses the 
 same conventions for listening to events (i.e. it has `handle*()` methods for 
-each event it's interested in). Instead of a `DomainMessage` instance, each
-of the `handle*()` methods receives a `Broadway\Saga\State` object as the
-second argument.
+each event it's interested in). The major difference is that the first argument 
+of the `handle*()` receive the `Broadway\Saga\State` object, followed by 
+`event` and `DomainMessage`. 
 
 A `handle*()` method should always return a `State` object, which will be 
 persisted afterwards. The `State` object can be used to store anything that's

--- a/examples/ReservationSaga.php
+++ b/examples/ReservationSaga.php
@@ -52,7 +52,7 @@ class ReservationSaga extends Saga implements StaticallyConfiguredSagaInterface
         ];
     }
 
-    public function handleOrderPlaced(OrderPlaced $event, State $state)
+    public function handleOrderPlaced(State $state, OrderPlaced $event)
     {
         // keep the order id, for reference in `handleReservationAccepted()` and `handleReservationRejected()`
         $state->set('orderId', $event->orderId());
@@ -68,7 +68,7 @@ class ReservationSaga extends Saga implements StaticallyConfiguredSagaInterface
         return $state;
     }
 
-    public function handleReservationAccepted(ReservationAccepted $event, State $state)
+    public function handleReservationAccepted(State $state, ReservationAccepted $event)
     {
         // the seat reservation for the given order is has been accepted, mark the order as booked
         $command = new MarkOrderAsBooked($state->get('orderId'));
@@ -80,7 +80,7 @@ class ReservationSaga extends Saga implements StaticallyConfiguredSagaInterface
         return $state;
     }
 
-    public function handleReservationRejected(ReservationRejected $event, State $state)
+    public function handleReservationRejected(State $state, ReservationRejected $event)
     {
         // the seat reservation for the given order is has been rejected, reject the order as well
         $command = new RejectOrder($state->get('orderId'));

--- a/src/Metadata/Metadata.php
+++ b/src/Metadata/Metadata.php
@@ -11,6 +11,7 @@
 
 namespace Broadway\Saga\Metadata;
 
+use Broadway\Domain\DomainMessage;
 use Broadway\Saga\MetadataInterface;
 use RuntimeException;
 
@@ -29,9 +30,9 @@ class Metadata implements MetadataInterface
     /**
      * {@inheritDoc}
      */
-    public function handles($event)
+    public function handles(DomainMessage $domainMessage)
     {
-        $eventName = $this->getClassName($event);
+        $eventName = $this->getClassName($domainMessage);
 
         return isset($this->criteria[$eventName]);
     }
@@ -39,19 +40,19 @@ class Metadata implements MetadataInterface
     /**
      * {@inheritDoc}
      */
-    public function criteria($event)
+    public function criteria(DomainMessage $domainMessage)
     {
-        $eventName = $this->getClassName($event);
-
-        if (! isset($this->criteria[$eventName])) {
+        $eventName = $this->getClassName($domainMessage);
+        if (!$this->handles($domainMessage)) {
             throw new RuntimeException(sprintf("No criteria for event '%s'.", $eventName));
         }
 
-        return $this->criteria[$eventName]($event);
+        return $this->criteria[$eventName]($domainMessage->getPayload(), $domainMessage);
     }
 
-    private function getClassName($event)
+    private function getClassName(DomainMessage $domainMessage)
     {
+        $event = $domainMessage->getPayload();
         $classParts = explode('\\', get_class($event));
 
         return end($classParts);

--- a/src/MetadataInterface.php
+++ b/src/MetadataInterface.php
@@ -11,19 +11,22 @@
 
 namespace Broadway\Saga;
 
+use Broadway\Domain\DomainMessage;
 use Broadway\Saga\State\Criteria;
 
 interface MetadataInterface
 {
     /**
-     * @param mixed $event
+     * @param DomainMessage $domainMessage
      *
      * @return boolean True, if the saga can handle the event
      */
-    public function handles($event);
+    public function handles(DomainMessage $domainMessage);
 
     /**
+     * @param DomainMessage $domainMessage
+     *
      * @return Criteria Criteria for the given event
      */
-    public function criteria($event);
+    public function criteria(DomainMessage $domainMessage);
 }

--- a/src/MultipleSagaManager.php
+++ b/src/MultipleSagaManager.php
@@ -23,7 +23,15 @@ use Broadway\Saga\State\StateManagerInterface;
 class MultipleSagaManager implements SagaManagerInterface
 {
     private $repository;
+    /**
+     * @var Saga[]
+     */
+    private $sagas = [];
     private $stateManager;
+    /**
+     * @var MetadataFactoryInterface
+     */
+    private $metadataFactory;
     private $eventDispatcher;
 
     public function __construct(
@@ -45,16 +53,14 @@ class MultipleSagaManager implements SagaManagerInterface
      */
     public function handle(DomainMessage $domainMessage)
     {
-        $event = $domainMessage->getPayload();
-
         foreach ($this->sagas as $sagaType => $saga) {
             $metadata = $this->metadataFactory->create($saga);
 
-            if (! $metadata->handles($event)) {
+            if (! $metadata->handles($domainMessage)) {
                 continue;
             }
 
-            $state = $this->stateManager->findOneBy($metadata->criteria($event), $sagaType);
+            $state = $this->stateManager->findOneBy($metadata->criteria($domainMessage), $sagaType);
 
             if (null === $state) {
                 continue;
@@ -64,7 +70,7 @@ class MultipleSagaManager implements SagaManagerInterface
                 [$sagaType, $state->getId()]
             );
 
-            $newState = $saga->handle($event, $state);
+            $newState = $saga->handle($state, $domainMessage);
 
             $this->eventDispatcher->dispatch(
                 SagaManagerInterface::EVENT_POST_HANDLE,

--- a/src/Saga.php
+++ b/src/Saga.php
@@ -11,13 +11,16 @@
 
 namespace Broadway\Saga;
 
+use Broadway\Domain\DomainMessage;
+
 abstract class Saga implements SagaInterface
 {
     /**
      * {@inheritDoc}
      */
-    public function handle($event, State $state)
+    public function handle(State $state, DomainMessage $domainMessage)
     {
+        $event = $domainMessage->getPayload();
         $method = $this->getHandleMethod($event);
 
         if (! method_exists($this, $method)) {
@@ -30,7 +33,7 @@ abstract class Saga implements SagaInterface
             );
         }
 
-        return $this->$method($event, $state);
+        return $this->$method($state, $event, $domainMessage);
     }
 
     private function getHandleMethod($event)

--- a/src/SagaInterface.php
+++ b/src/SagaInterface.php
@@ -11,12 +11,15 @@
 
 namespace Broadway\Saga;
 
+use Broadway\Domain\DomainMessage;
+
 interface SagaInterface
 {
     /**
-     * @param mixed $event
+     * @param State $state
+     * @param DomainMessage $domainMessage
      *
      * @return State
      */
-    public function handle($event, State $state);
+    public function handle(State $state, DomainMessage $domainMessage);
 }

--- a/src/Testing/Scenario.php
+++ b/src/Testing/Scenario.php
@@ -22,6 +22,7 @@ class Scenario
     private $testCase;
     private $sagaManager;
     private $traceableCommandBus;
+    private $aggregateId;
     private $playhead;
 
     public function __construct(
@@ -32,9 +33,22 @@ class Scenario
         $this->testCase            = $testCase;
         $this->sagaManager         = $sagaManager;
         $this->traceableCommandBus = $traceableCommandBus;
+        $this->aggregateId         = 1;
         $this->playhead            = -1;
     }
 
+    /**
+     * @param string $aggregateId
+     *
+     * @return Scenario
+     */
+    public function withAggregateId($aggregateId)
+    {
+        $this->aggregateId = $aggregateId;
+
+        return $this;
+    }
+    
     /**
      * @param array $events
      *
@@ -79,6 +93,6 @@ class Scenario
     {
         $this->playhead++;
 
-        return DomainMessage::recordNow(1, $this->playhead, new Metadata([]), $event);
+        return DomainMessage::recordNow($this->aggregateId, $this->playhead, new Metadata([]), $event);
     }
 }

--- a/test/Metadata/MetadataTest.php
+++ b/test/Metadata/MetadataTest.php
@@ -11,14 +11,21 @@
 
 namespace Broadway\Saga\Metadata;
 
+use Broadway\Domain\DomainMessage;
+
 class StaticallyConfiguredSagaMetadataTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var Metadata
+     */
     private $metadata;
 
     public function setUp()
     {
         $this->metadata = new Metadata([
-            'StaticallyConfiguredSagaMetadataTestSagaTestEvent1' => function () { return 'criteria'; },
+            'StaticallyConfiguredSagaMetadataTestSagaTestEvent1' => function () {
+                return 'criteria';
+            },
         ]);
     }
 
@@ -28,8 +35,9 @@ class StaticallyConfiguredSagaMetadataTest extends \PHPUnit_Framework_TestCase
     public function it_handles_an_event_if_its_specified_by_the_saga()
     {
         $event = new StaticallyConfiguredSagaMetadataTestSagaTestEvent1();
+        $domainMessage = $this->createDomainMessage($event);
 
-        $this->assertTrue($this->metadata->handles($event));
+        $this->assertTrue($this->metadata->handles($domainMessage));
     }
 
     /**
@@ -38,8 +46,9 @@ class StaticallyConfiguredSagaMetadataTest extends \PHPUnit_Framework_TestCase
     public function it_does_not_handle_an_event_if_its_not_specified_by_the_saga()
     {
         $event = new StaticallyConfiguredSagaMetadataTestSagaTestEvent2();
+        $domainMessage = $this->createDomainMessage($event);
 
-        $this->assertFalse($this->metadata->handles($event));
+        $this->assertFalse($this->metadata->handles($domainMessage));
     }
 
     /**
@@ -48,8 +57,9 @@ class StaticallyConfiguredSagaMetadataTest extends \PHPUnit_Framework_TestCase
     public function it_returns_the_criteria_for_a_configured_event()
     {
         $event = new StaticallyConfiguredSagaMetadataTestSagaTestEvent1();
+        $domainMessage = $this->createDomainMessage($event);
 
-        $this->assertEquals('criteria', $this->metadata->criteria($event));
+        $this->assertEquals('criteria', $this->metadata->criteria($domainMessage));
     }
 
     /**
@@ -59,8 +69,14 @@ class StaticallyConfiguredSagaMetadataTest extends \PHPUnit_Framework_TestCase
     public function it_throws_an_exception_if_there_is_no_criteria_for_a_given_event()
     {
         $event = new StaticallyConfiguredSagaMetadataTestSagaTestEvent2();
+        $domainMessage = $this->createDomainMessage($event);
 
-        $this->metadata->criteria($event);
+        $this->metadata->criteria($domainMessage);
+    }
+
+    private function createDomainMessage($event): DomainMessage
+    {
+        return DomainMessage::recordNow('id', 0, new \Broadway\Domain\Metadata([]), $event);
     }
 }
 

--- a/test/Metadata/StaticallyConfiguredSagaMetadataFactoryTest.php
+++ b/test/Metadata/StaticallyConfiguredSagaMetadataFactoryTest.php
@@ -11,6 +11,8 @@
 
 namespace Broadway\Saga\Metadata;
 
+use Broadway\Domain\DomainMessage;
+use Broadway\Saga\State;
 use Broadway\Saga\State\Criteria;
 
 class StaticallyConfiguredSagaMetadataFactoryTest extends \PHPUnit_Framework_TestCase
@@ -20,25 +22,40 @@ class StaticallyConfiguredSagaMetadataFactoryTest extends \PHPUnit_Framework_Tes
      */
     public function it_creates_metadata_using_the_saga_configuration()
     {
-        $this->markTestSkipped('Yay phpunit');
         $metadataFactory = new StaticallyConfiguredSagaMetadataFactory();
-        $criteria        = new Criteria(['id' => 'YoLo']);
-
-        $saga = $this->getMockBuilder('Broadway\Saga\Metadata\StaticallyConfiguredSagaInterface')->getMock();
-        $saga->staticExpects($this->any())
-            ->method('configuration')
-            ->will($this->returnValue(['StaticallyConfiguredSagaMetadataFactoryTestEvent' => function ($event) use ($criteria) { return $criteria;}]));
-
+        $saga = new StaticallyConfiguredSaga();
         $metadata = $metadataFactory->create($saga);
 
         $this->assertInstanceOf('Broadway\Saga\MetadataInterface', $metadata);
 
         $event = new StaticallyConfiguredSagaMetadataFactoryTestEvent();
-        $this->assertTrue($metadata->handles($event));
-        $this->assertEquals($criteria, $metadata->criteria($event));
+        $domainMessage = DomainMessage::recordNow('id', 0, new \Broadway\Domain\Metadata([]), $event);
+
+        $this->assertTrue($metadata->handles($domainMessage));
+        $this->assertEquals(
+            new Criteria(['id' => $domainMessage->getId()]),
+            $metadata->criteria($domainMessage)
+        );
     }
 }
 
 class StaticallyConfiguredSagaMetadataFactoryTestEvent
 {
+}
+
+class StaticallyConfiguredSaga implements StaticallyConfiguredSagaInterface
+{
+    public function handle(State $state, DomainMessage $domainMessage)
+    {
+        return $state;
+    }
+
+    public static function configuration()
+    {
+        return [
+            'StaticallyConfiguredSagaMetadataFactoryTestEvent' => function ($event, DomainMessage $domainMessage) {
+                return new Criteria(['id' => $domainMessage->getId()]);
+            }
+        ];
+    }
 }

--- a/test/MultipleSagaManagerTest.php
+++ b/test/MultipleSagaManagerTest.php
@@ -253,9 +253,10 @@ class MultipleSagaManagerTest extends \PHPUnit_Framework_TestCase
 class SagaManagerTestSaga implements StaticallyConfiguredSagaInterface
 {
     public $isCalled = false;
-    public function handle($event, State $state = null)
+    public function handle(State $state, DomainMessage $domainMessage)
     {
         $this->isCalled = true;
+        $event = $domainMessage->getPayload();
 
         if ($event instanceof TestEvent1) {
             $state->set('event', 'testevent1');
@@ -271,9 +272,14 @@ class SagaManagerTestSaga implements StaticallyConfiguredSagaInterface
     public static function configuration()
     {
         return [
-            'TestEvent1'    => function () { return new Criteria(['appId' => 42]); },
-            'TestEvent2'                                                  => function () { },
-            'TestEventDone'                                               => function () { return new Criteria(['appId' => 42]); },
+            'TestEvent1' => function () {
+                return new Criteria(['appId' => 42]);
+            },
+            'TestEvent2' => function () {
+            },
+            'TestEventDone' => function () {
+                return new Criteria(['appId' => 42]);
+            },
         ];
     }
 }


### PR DESCRIPTION
The `Sagas` are now handled with 
the `DomainMessage` instead of the `event`. This makes it more consistent with the 
rest of the broadway framework, where all event listeners are handled with the 
`DomainMessage`.

The problem i have with the current version is that i miss the DomainMessage to fetch data. Now i am using `DomainMessage::getId()` in my other event listeners (Projectors, Processors).