### PR TITLE
Allow beberlei/assert 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "require": {
     "php": ">=7.0",
     "broadway/broadway": "^2.0",
-    "beberlei/assert": "^2.0"
+    "beberlei/assert": "~2.0 || ~3.0"
   },
   "authors": [
     {


### PR DESCRIPTION
No breaking changes, only that they dropped < PHP 7.0